### PR TITLE
Add react icons

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -17,6 +17,7 @@
     "react": "^17.0.2",
     "react-click-away-listener": "^2.1.0",
     "react-dom": "^17.0.2",
+    "react-icons": "^4.3.1",
     "react-redux": "^7.2.0",
     "react-router-dom": "^6.2.1",
     "react-scripts": "5.0.0",

--- a/frontend/src/pages/Check/Check.tsx
+++ b/frontend/src/pages/Check/Check.tsx
@@ -6,7 +6,7 @@ import { haiListSelector, add } from "../../app/HaiListSlice";
 import "./Check.scss";
 interface Props {}
 
-export const Check: React.FC<Props> = ({}) => {
+export const Check: React.FC<Props> = () => {
   const dispatch = useAppDispatch();
   const haiList = useAppSelector(haiListSelector);
   return (

--- a/frontend/src/pages/Result/Result.tsx
+++ b/frontend/src/pages/Result/Result.tsx
@@ -7,7 +7,7 @@ import "./Result.scss";
 
 interface Props {}
 
-export const Result: React.FC<Props> = ({}) => {
+export const Result: React.FC<Props> = () => {
   const dispatch = useAppDispatch();
   const haiList = useAppSelector(haiListSelector);
   return (

--- a/frontend/src/pages/Top/Top.tsx
+++ b/frontend/src/pages/Top/Top.tsx
@@ -9,7 +9,7 @@ import { MdOutlineCameraAlt } from 'react-icons/md';
 import { color } from "assets/color";
 interface Props {}
 
-export const Top: React.FC<Props> = ({}) => {
+export const Top: React.FC<Props> = () => {
   const dispatch = useAppDispatch();
 
   const haiList = useAppSelector(haiListSelector);

--- a/frontend/src/pages/Top/Top.tsx
+++ b/frontend/src/pages/Top/Top.tsx
@@ -5,6 +5,8 @@ import { haiListSelector, add } from "../../app/HaiListSlice";
 import { Link } from "react-router-dom";
 import { Hai } from "components/Hai";
 import { HaiSelector } from "components/HaiSelector/HaiSelector";
+import { MdOutlineCameraAlt } from 'react-icons/md';
+import { color } from "assets/color";
 interface Props {}
 
 export const Top: React.FC<Props> = ({}) => {
@@ -35,6 +37,7 @@ export const Top: React.FC<Props> = ({}) => {
       <Hai type="s" number={1}></Hai>
       <HaiSelector isType initSelected={0} />
       <HaiSelector type="m" initSelected={0} />
+      <MdOutlineCameraAlt size={32} color={color.MainGreen} title="Take picture!"/>
     </>
   );
 };

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -7379,6 +7379,11 @@ react-error-overlay@^6.0.10:
   resolved "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.10.tgz"
   integrity sha512-mKR90fX7Pm5seCOfz8q9F+66VCc1PGsWSBxKbITjfKVQHMNF2zudxHnMdJiB1fRCb+XsbQV9sO9DCkgsMQgBIA==
 
+react-icons@^4.3.1:
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/react-icons/-/react-icons-4.3.1.tgz#2fa92aebbbc71f43d2db2ed1aed07361124e91ca"
+  integrity sha512-cB10MXLTs3gVuXimblAdI71jrJx8njrJZmNMEMC+sQu5B/BIOmlsAjskdqpn81y8UBVEGuHODd7/ci5DvoSzTQ==
+
 react-is@^16.12.0, "react-is@^16.12.0 || ^17.0.0", react-is@^16.13.1, react-is@^16.7.0, react-is@^16.8.4:
   version "16.13.1"
   resolved "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz"


### PR DESCRIPTION
Issue: #46

### アイコンについて
- [react-icons](https://react-icons.github.io/react-icons/) を使用。
- iconのアセットは [Material Design Icons](https://materialdesignicons.com/)（短縮系 `Md`）から使用
  - [react-iconsの公式サイト](https://react-icons.github.io/react-icons/icons?name=md)からアイコン名で検索をかければヒットします。
  - `MdOutlineCameraAlt` みたいに PascalCase になっているので検索時は注意。
  
### 仕様について
```js
// icon名でimportする
import { MdOutlineCameraAlt } from 'react-icons/md';
import { color } from "assets/color";

export const Hoge: React.FC = () => {
  return (
    // 直接 size, color, title を指定
    <MdOutlineCameraAlt size={32} color={color.MainGreen} title="Take picture!"/>
  );
};
```

- 24pxと、32pxを `size` で切り替えられる。
- 色を `color` で指定できる。

アイコンはFigmaに置いてあるこいつら
<img width="942" alt="image" src="https://user-images.githubusercontent.com/23555983/152488251-70c4ed5c-677d-4a1c-8af3-7aca3cbf728f.png">