### PR TITLE
牌選択用ポップアップの実装

### DIFF
--- a/frontend/src/components/HaiSelectPopup/HaiSelectPopup.scss
+++ b/frontend/src/components/HaiSelectPopup/HaiSelectPopup.scss
@@ -3,6 +3,7 @@
         display:inline-block;
         min-width: 512px;
         height:112px;
+        position:relative;
     }
     &__panel{
         display:flex;
@@ -13,5 +14,11 @@
         align-items:center;
         justify-content: space-between;
         padding:0 32px;
+    }
+    &__close{
+        padding:8px;
+        position:absolute;
+        top:0;
+        right:0;
     }
 }

--- a/frontend/src/components/HaiSelectPopup/HaiSelectPopup.scss
+++ b/frontend/src/components/HaiSelectPopup/HaiSelectPopup.scss
@@ -1,0 +1,17 @@
+.Popup{
+    &__box{
+        display:inline-block;
+        min-width: 512px;
+        height:112px;
+    }
+    &__panel{
+        display:flex;
+        width:auto;
+        height:112px;
+        background: #F0F4F2;
+        border-radius: 16px;
+        align-items:center;
+        justify-content: space-between;
+        padding:0 32px;
+    }
+}

--- a/frontend/src/components/HaiSelectPopup/HaiSelectPopup.tsx
+++ b/frontend/src/components/HaiSelectPopup/HaiSelectPopup.tsx
@@ -1,0 +1,25 @@
+import classNames from "classnames";
+import { HaiSelectorPair } from "components/HaiSelectorPair";
+import React, { useState } from "react";
+import ClickAwayListener from "react-click-away-listener";
+import "./HaiSelectPopup.scss";
+type HaiProps = {
+  type: HaiType;
+  number: number;
+};
+type Props = { initHai: HaiProps };
+type HaiType = "m" | "p" | "s" | "z";
+
+const typeList = ["m", "p", "s", "z"] as HaiType[];
+const Type2Index = { m: 0, p: 1, s: 2, z: 3 };
+
+export const HaiSelectPopup: React.FC<Props> = ({ initHai }) => {
+  return (
+    <div className="Popup__box">
+      <div className="Popup__panel">
+        <div className="Popup__text">牌の種類を選択</div>
+        <HaiSelectorPair initHai={initHai} />
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/components/HaiSelectPopup/HaiSelectPopup.tsx
+++ b/frontend/src/components/HaiSelectPopup/HaiSelectPopup.tsx
@@ -1,25 +1,38 @@
-import classNames from "classnames";
 import { HaiSelectorPair } from "components/HaiSelectorPair";
-import React, { useState } from "react";
-import ClickAwayListener from "react-click-away-listener";
+import React from "react";
+import { MdClose } from "react-icons/md";
+import { color } from "assets/color";
 import "./HaiSelectPopup.scss";
 type HaiProps = {
   type: HaiType;
   number: number;
 };
-type Props = { initHai: HaiProps };
+type Props = { initHai: HaiProps; disable?: boolean; onClose?: Function };
 type HaiType = "m" | "p" | "s" | "z";
 
 const typeList = ["m", "p", "s", "z"] as HaiType[];
 const Type2Index = { m: 0, p: 1, s: 2, z: 3 };
 
-export const HaiSelectPopup: React.FC<Props> = ({ initHai }) => {
+export const HaiSelectPopup: React.FC<Props> = ({
+  initHai,
+  disable = false,
+  onClose,
+}) => {
   return (
-    <div className="Popup__box">
-      <div className="Popup__panel">
-        <div className="Popup__text">牌の種類を選択</div>
-        <HaiSelectorPair initHai={initHai} />
-      </div>
-    </div>
+    <>
+      {!disable && (
+        <div className="Popup__box">
+          {onClose && (
+            <div className="Popup__close" onClick={() => onClose()}>
+              <MdClose size={24} color={color.MainGreen} title="Close Popup!" />
+            </div>
+          )}
+          <div className="Popup__panel">
+            <div className="Popup__text">牌の種類を選択</div>
+            <HaiSelectorPair initHai={initHai} />
+          </div>
+        </div>
+      )}
+    </>
   );
 };

--- a/frontend/src/components/HaiSelectPopup/index.tsx
+++ b/frontend/src/components/HaiSelectPopup/index.tsx
@@ -1,0 +1,1 @@
+export { HaiSelectPopup } from "./HaiSelectPopup";

--- a/frontend/src/components/HaiSelector/HaiSelector.tsx
+++ b/frontend/src/components/HaiSelector/HaiSelector.tsx
@@ -1,6 +1,6 @@
 import classNames from "classnames";
 import { Hai } from "components/Hai";
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import ClickAwayListener from "react-click-away-listener";
 import "./HaiSelector.scss";
 
@@ -53,7 +53,8 @@ const HaiSelectorWindow: React.FC<WindowProps> = ({
       itemList.push({ text, icon: { number: 1, type: typeList[index] } });
     });
   } else {
-    for (var i = 1; i <= 9; i++)
+    const maxLoop = type == "z" ? 7 : 9;
+    for (var i = 1; i <= maxLoop; i++)
       itemList.push({ text: i + type, icon: { number: i, type: type } });
   }
   return (
@@ -100,6 +101,19 @@ export const HaiSelector: React.FC<HaiSelectorProps> = ({
     setText(isType ? typeKanji[index] : index + 1 + "" + type);
     onChange && onChange(index);
   };
+
+  useEffect(() => {
+    if (type == "z" && selected >= 7) {
+      setSelected(0);
+      onChange && onChange(0);
+    }
+    setIcon(
+      (isType
+        ? { type: typeList[selected], number: 1 }
+        : { type, number: selected + 1 }) as HaiProps
+    );
+    setText(isType ? typeKanji[selected] : selected + 1 + "" + type);
+  }, [type, selected]);
   return (
     <ClickAwayListener onClickAway={() => setIsShown(false)}>
       <div className="HaiSelector__box">

--- a/frontend/src/components/HaiSelector/index.tsx
+++ b/frontend/src/components/HaiSelector/index.tsx
@@ -1,0 +1,1 @@
+export { HaiSelector } from "./HaiSelector";

--- a/frontend/src/components/HaiSelectorPair/HaiSelectorPair.scss
+++ b/frontend/src/components/HaiSelectorPair/HaiSelectorPair.scss
@@ -1,0 +1,8 @@
+.Pair{
+    &__box{
+    }
+    &__selector{
+        display: inline-block;
+        padding: 0 8px;
+    }
+}

--- a/frontend/src/components/HaiSelectorPair/HaiSelectorPair.tsx
+++ b/frontend/src/components/HaiSelectorPair/HaiSelectorPair.tsx
@@ -1,0 +1,34 @@
+import { HaiSelector } from "components/HaiSelector/HaiSelector";
+import React, { useState } from "react";
+import "./HaiSelectorPair.scss";
+type HaiProps = {
+  type: HaiType;
+  number: number;
+};
+type Props = { initHai: HaiProps };
+type HaiType = "m" | "p" | "s" | "z";
+
+const typeList = ["m", "p", "s", "z"] as HaiType[];
+const Type2Index = { m: 0, p: 1, s: 2, z: 3 };
+export const HaiSelectorPair: React.FC<Props> = ({ initHai }) => {
+  const [type, setType] = useState(initHai.type);
+  const [number, setNumber] = useState(initHai.number);
+  return (
+    <div className="Pair__box">
+      <div className="Pair__selector">
+        <HaiSelector
+          isType
+          initSelected={Type2Index[type]}
+          onChange={(index: number) => setType(typeList[index])}
+        />
+      </div>
+      <div className="Pair__selector">
+        <HaiSelector
+          type={type}
+          initSelected={number - 1}
+          onChange={(index: number) => setNumber(index + 1)}
+        />
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/components/HaiSelectorPair/index.tsx
+++ b/frontend/src/components/HaiSelectorPair/index.tsx
@@ -1,0 +1,1 @@
+export { HaiSelectorPair } from "./HaiSelectorPair";

--- a/frontend/src/pages/Check/Check.tsx
+++ b/frontend/src/pages/Check/Check.tsx
@@ -4,6 +4,7 @@ import { Link } from "react-router-dom";
 import { useAppDispatch, useAppSelector } from "../../app/store";
 import { haiListSelector, add } from "../../app/HaiListSlice";
 import "./Check.scss";
+import { HaiSelectPopup } from "components/HaiSelectPopup";
 interface Props {}
 
 export const Check: React.FC<Props> = () => {
@@ -27,6 +28,10 @@ export const Check: React.FC<Props> = () => {
       </button>
       <br />
       <Link to="/result">点数画面へ遷移</Link>
+      <HaiSelectPopup
+        initHai={{ type: "m", number: 1 }}
+        onClose={() => console.log("close")}
+      />
     </>
   );
 };

--- a/frontend/src/pages/Top/Top.tsx
+++ b/frontend/src/pages/Top/Top.tsx
@@ -6,7 +6,6 @@ import { Link } from "react-router-dom";
 import { Hai } from "components/Hai";
 import { MdOutlineCameraAlt } from "react-icons/md";
 import { color } from "assets/color";
-import { HaiSelectPopup } from "components/HaiSelectPopup/HaiSelectPopup";
 interface Props {}
 
 export const Top: React.FC<Props> = () => {
@@ -40,7 +39,6 @@ export const Top: React.FC<Props> = () => {
         color={color.MainGreen}
         title="Take picture!"
       />
-      <HaiSelectPopup initHai={{ type: "m", number: 1 }} />
     </>
   );
 };

--- a/frontend/src/pages/Top/Top.tsx
+++ b/frontend/src/pages/Top/Top.tsx
@@ -4,9 +4,9 @@ import { useAppDispatch, useAppSelector } from "../../app/store";
 import { haiListSelector, add } from "../../app/HaiListSlice";
 import { Link } from "react-router-dom";
 import { Hai } from "components/Hai";
-import { HaiSelector } from "components/HaiSelector/HaiSelector";
-import { MdOutlineCameraAlt } from 'react-icons/md';
+import { MdOutlineCameraAlt } from "react-icons/md";
 import { color } from "assets/color";
+import { HaiSelectPopup } from "components/HaiSelectPopup/HaiSelectPopup";
 interface Props {}
 
 export const Top: React.FC<Props> = () => {
@@ -35,9 +35,12 @@ export const Top: React.FC<Props> = () => {
       <br />
       <Link to="/check">確認画面へ遷移</Link>
       <Hai type="s" number={1}></Hai>
-      <HaiSelector isType initSelected={0} />
-      <HaiSelector type="m" initSelected={0} />
-      <MdOutlineCameraAlt size={32} color={color.MainGreen} title="Take picture!"/>
+      <MdOutlineCameraAlt
+        size={32}
+        color={color.MainGreen}
+        title="Take picture!"
+      />
+      <HaiSelectPopup initHai={{ type: "m", number: 1 }} />
     </>
   );
 };


### PR DESCRIPTION
- ２つのセレクタが連動する
  - 字牌を選んだときに存在しない8z以上のときは，1zに戻す
- ×をおすと，引数のonCloseが実行される
  - 親側でダイアログの表示非表示の状態管理するため
- HaiSelectorPairをコンポーネントとして切り出しました
  - ドラを設定するとき用