### PR TITLE
Photo processing

### DIFF
--- a/frontend/src/pages/CameraPage/CameraPage.tsx
+++ b/frontend/src/pages/CameraPage/CameraPage.tsx
@@ -2,7 +2,6 @@ import { FC, useRef } from "react";
 import { MdOutlineCameraAlt, MdFlipCameraAndroid } from 'react-icons/md';
 import { color } from "assets/color";
 import { Camera, CameraHandles } from "./components/Camera";
-import { useNavigate } from "react-router-dom";
 import {
   Wrapper,
   CameraWrapper,
@@ -13,11 +12,8 @@ import {
 
 export const CameraPage: FC = () => {
   const cameraRef = useRef<CameraHandles>(null);
-  const navigate = useNavigate();
   const takeCapture = () => {
     cameraRef.current?.capture();
-
-    navigate("/check");
   };
 
   const switchCamera = () => {

--- a/frontend/src/pages/CameraPage/components/Camera.tsx
+++ b/frontend/src/pages/CameraPage/components/Camera.tsx
@@ -7,6 +7,7 @@ import {
   ForwardRefRenderFunction,
 } from "react";
 import { Camera as ReactCamera, CameraType } from "react-camera-pro";
+import { useNavigate } from "react-router-dom";
 import { Wrapper, ScreenShot } from "./CameraStyle";
 
 export interface CameraHandles {
@@ -31,6 +32,7 @@ const Component: ForwardRefRenderFunction<CameraHandles> = (_, ref) => {
   const cameraRef = useRef<CameraType>(null)
   const wrapperRef = useRef<HTMLDivElement | null>(null)
   const [url, setUrl] = useState<string | undefined>(undefined)
+  const navigate = useNavigate();
 
   const capture = () => {
     if (!cameraRef.current) return;
@@ -48,7 +50,7 @@ const Component: ForwardRefRenderFunction<CameraHandles> = (_, ref) => {
     console.log(base64)
 
     // TODO: upload data:image/jpeg;base64 file
-
+    navigate("/check");
   }
 
   const cropAndResizeB64 = async (imgB64_src: string, aspectRatio: number): Promise<string | null> => {

--- a/frontend/src/pages/CameraPage/components/Camera.tsx
+++ b/frontend/src/pages/CameraPage/components/Camera.tsx
@@ -24,16 +24,36 @@ const errorMessages = {
   canvas: "Canvasが対応していません。",
 };
 
+const CROP_WIDTH = 512
+const CROP_HEIGHT = 512
+
 const Component: ForwardRefRenderFunction<CameraHandles> = (_, ref) => {
   const cameraRef = useRef<CameraType>(null)
   const wrapperRef = useRef<HTMLDivElement | null>(null)
   const [url, setUrl] = useState<string | undefined>(undefined)
 
-  const capture = useCallback(() => {
+  const capture = () => {
     if (!cameraRef.current) return;
     const imageSrc = cameraRef.current.takePhoto();
     setUrl(imageSrc);
-  }, [cameraRef]);
+    uploadResizeImage(imageSrc);
+  };
+
+  const uploadResizeImage = (imageSrc: string) => {
+    if(!wrapperRef.current) return null;
+    const width = wrapperRef.current.clientWidth
+    const height = wrapperRef.current.clientHeight
+    const aspectRatio = height / width
+    const base64 = cropAndResizeB64(imageSrc, aspectRatio)
+    console.log(base64)
+
+    // TODO: upload data:image/jpeg;base64 file
+
+  }
+
+  const cropAndResizeB64 = (imgB64_src: string, aspectRatio: number): string => {
+    return 'data:image/jpeg;base64,xxx...'
+  }
 
   const switchCamera = useCallback(() => {
     if (!cameraRef.current) return;


### PR DESCRIPTION
# やったこと
- 撮影した画像を512*512に収まるように縮小
  - トリミングだと牌の部分を切り取ってしまいかねないので、画像がはみ出さない最大サイズに縮小。いわゆる `background-size: contain;` の処理。
  - 画像以外の空いた領域は黒に塗りつぶされる。
- base64化
# やってない事
- base64をサーバーへ上げる



