### PR TITLE
iOSでNoto Sans JPを表示できるようにする

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,20 +1,22 @@
+	
+@import url(http://fonts.googleapis.com/earlyaccess/notosansjp.css);
 html {
   height: 100%;
 }
 
 body {
   margin: 0;
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen",
-    "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue",
-    sans-serif;
+
+  font-family: Noto Sans JP;
+  
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   height: 100%;
 }
 
 code {
-  font-family: source-code-pro, Menlo, Monaco, Consolas, "Courier New",
-    monospace;
+  
+  font-family: Noto Sans JP;
 }
 
 #root {


### PR DESCRIPTION
index.cssに以下を追加
```
@import url(http://fonts.googleapis.com/earlyaccess/notosansjp.css);
```


